### PR TITLE
example metric getting Subs

### DIFF
--- a/src/metrics.test.ts
+++ b/src/metrics.test.ts
@@ -1,4 +1,4 @@
-import { BusFactor, Responsiveness, Correctness, License, RampUp } from "./metrics";
+import { BusFactor, Responsiveness, Correctness, License, RampUp, Subs } from "./metrics";
 
 describe("BusFactor", () => {
 	it("should return a bus factor", async () => {
@@ -42,5 +42,14 @@ describe("Correctness", () => {
 		const score = await correctnessMetric.evaluate();
 		expect(score).toBeDefined();
 		expect(correctnessMetric.name).toBe("Correctness");
+	});
+});
+
+describe("Subs", () => {
+	it("should return # of subs", async () => {
+		const subsMetric = new Subs("https://github.com/example/repo", "fake-token"); //passing in url accurately pending
+		const score = await subsMetric.evaluate();
+		expect(score).toBeDefined();
+		expect(subsMetric.name).toBe("Subs");
 	});
 });

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,4 +1,5 @@
 import { Octokit } from "octokit";
+import process from "process";
 
 export interface Metric {
 	name: string;
@@ -73,5 +74,20 @@ export class Correctness extends BaseMetric {
 
 	async evaluate(): Promise<number> {
 		return 0.5; // Just a placeholder. TODO: implement.
+	}
+}
+
+export class Subs extends BaseMetric {
+	name = "Subs";
+	description = "Measures # subs.";
+
+	octokit = new Octokit({ auth: process.env.SECRET_WORD });
+
+	async evaluate(): Promise<number> {
+		const repos = await this.octokit.rest.repos.get({
+			owner: "neovim",
+			repo: "neovim",
+		});
+		return repos.data.subscribers_count;
 	}
 }


### PR DESCRIPTION
different form factor than original async operation, but works nicely inline + tested with metrics.