### PR TITLE
Removed node 16.x from workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [16.x, 18.x]
+                node-version: [18.x]
 
         steps:
             - uses: actions/checkout@v3


### PR DESCRIPTION
We're only graded with Node 18.x