### PR TITLE
Run install

### DIFF
--- a/run
+++ b/run
@@ -1,3 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env python3
 
-node ./dist/index.js $1
+import subprocess
+import sys
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: ./run <argument>")
+        sys.exit(1)
+    
+    argument = sys.argv[1]
+    command = ["node", "./dist/index.js", argument]
+    
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"An error occurred: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ export function setupCLI() {
 		.command("install")
 		.description("Installs dependencies")
 		.action(() => {
-			exec("npm ci", (error, stdout, stderr) => {
+			exec("npm ci", (error, stdout) => {
 				if (error) {
 					console.error(`Error during installation: ${error}`);
 					return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import URLParser from "./URLParser";
+import { exec } from "child_process";
 
 export function setupCLI() {
 	const program = new Command();
@@ -10,7 +11,22 @@ export function setupCLI() {
 		.command("install")
 		.description("Installs dependencies")
 		.action(() => {
-			console.log("installing dependencies (but not really)");
+			exec("npm ci", (error, stdout, stderr) => {
+				if (error) {
+					console.error(`Error during installation: ${error}`);
+					return;
+				}
+
+				// Extract the number of packages installed
+				const regex = /added (\d+) packages/i;
+				const match = stdout.match(regex);
+				if (match && match[1]) {
+					console.log(`${match[1]} dependencies installed...`);
+				} else {
+					// could not determine amount of dependencies installed
+					console.log("Installed dependencies...");
+				}
+			});
 		});
 
 	program


### PR DESCRIPTION
# Things changed in this branch

1. Converted ./run from bash to python3
2. `./run install` runs `npm ci` under the hood. I don't think we have any other dependencies outside of from npm. Let me know if we do.
3. `./run install` outputs the number of dependencies installed exactly as the example output.